### PR TITLE
Removed --smallfiles line

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     image: mongo:latest
     ports:
       - 27017:27017
-    entrypoint: mongod --smallfiles --logpath=/dev/null --bind_ip "0.0.0.0"
+    entrypoint: mongod --logpath=/dev/null --bind_ip "0.0.0.0"
     networks:
       - epirus
 


### PR DESCRIPTION
--smallfiles  is a deprecated command in the latest [update](https://docs.mongodb.com/manual/reference/configuration-options/#removed-mmapv1-options)